### PR TITLE
Make `_t` return a string representation of the type of an object ins…

### DIFF
--- a/hask/lang/syntax.py
+++ b/hask/lang/syntax.py
@@ -1001,8 +1001,9 @@ def _t(obj):
     >>> _t(Just("hello world"))
     Maybe str
     """
-    print(str(typeof(obj)))
-    return
+    return str(typeof(obj))
+
+
 
 
 def _i(obj):


### PR DESCRIPTION
…tead of printing it.

Return seems much more useful here. Also the docstring says:  `Returns a string representing the type of an object ...`
